### PR TITLE
allow access from backend origin

### DIFF
--- a/client/public/_headers
+++ b/client/public/_headers
@@ -1,0 +1,2 @@
+/*
+  Access-Control-Allow-Origin: https://staging-minidoro.herokuapp.com


### PR DESCRIPTION
There is an issue where we cannot access the dashboard API in the backend, this is not an issue in local development but once hosted in production, it's known. Getting CORS error

changes:
- add _header file in public folder with index.html -- according to https://stackoverflow.com/questions/62507022/how-to-enable-cors-on-a-netlify-deployment